### PR TITLE
fix: cn-e1 supports thumbnails

### DIFF
--- a/core/src/main/java/cn/leancloud/AVFile.java
+++ b/core/src/main/java/cn/leancloud/AVFile.java
@@ -268,7 +268,7 @@ public final class AVFile extends AVObject {
   }
 
   public String getThumbnailUrl(boolean scaleToFit, int width, int height, int quality, String fmt) {
-    if (AVOSCloud.getRegion() != AVOSCloud.REGION.NorthChina) {
+    if (AVOSCloud.getRegion() == AVOSCloud.REGION.NorthAmerica) {
       logger.w("We only support this method for qiniu storage.");
       throw new UnsupportedOperationException("We only support this method for qiniu storage.");
     }


### PR DESCRIPTION
File provider of cn-e1 switched from qcloud to qiniu long long ago.