### PR TITLE
Fixed AVQuery查询时设置返回ACL权限且设置了缓存，而自己主动清除缓存时失败

### DIFF
--- a/core/src/main/java/cn/leancloud/AVQuery.java
+++ b/core/src/main/java/cn/leancloud/AVQuery.java
@@ -924,9 +924,6 @@ public class AVQuery<T extends AVObject> implements Cloneable {
 
   protected Observable<List<T>> findInBackground(int explicitLimit) {
     Map<String, String> query = assembleParameters();
-    if (this.includeACL && null != query) {
-      query.put("returnACL", "true");
-    }
     if (explicitLimit > 0) {
       query.put("limit", Integer.toString(explicitLimit));
     }
@@ -1046,12 +1043,19 @@ public class AVQuery<T extends AVObject> implements Cloneable {
    */
   public Map<String, String> assembleParameters() {
     conditions.assembleParameters();
-    return conditions.getParameters();
+    Map<String, String> query = conditions.getParameters();
+    if (this.includeACL && null != query) {
+      query.put("returnACL", "true");
+    }
+    return query;
   }
 
   protected Map<String, Object> assembleJsonParam() {
     Map<String, Object> result = conditions.assembleJsonParam();
     result.put("className", getClassName());
+    if (this.includeACL && null != query) {
+      result.put("returnACL", true);
+    }
     return result;
   }
 


### PR DESCRIPTION
详细我已反馈在LeanCloud论坛 https://forum.leancloud.cn/t/acl/23543

因为，得到的 String cacheKey = QueryResultCache.generateKeyForQueryCondition(getClassName(), query)，cacheKey 和 请求时缓存的cacheKey 不一致，永远无法自己主动清除缓存。